### PR TITLE
Update for latest function of OctoberCMS and AccesLog fix

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -9,6 +9,7 @@ use System\Classes\PluginBase;
  */
 class Plugin extends PluginBase
 {
+    public $elevated = true;
 
     /**
      * Returns information about this plugin.

--- a/routes.php
+++ b/routes.php
@@ -61,5 +61,5 @@ App::before(function ($request) {
         $request->server->set('REMOTE_ADDR', $_SERVER['HTTP_CF_CONNECTING_IP']);
     }
 
-    $request->setTrustedProxies($trusted_proxies);
+    $request->setTrustedProxies($trusted_proxies, \Illuminate\Http\Request::HEADER_X_FORWARDED_FOR);
 });


### PR DESCRIPTION
For this plugin to work in the latest version of OctoberCMS it requires 2 parameters.

For enabling the correct IP in the access logs (backend) the plugin needs elevated rights.